### PR TITLE
Modify the data layer and business layer, according to the format output data

### DIFF
--- a/Web/ExpressIM/src/com/stardust/express/actions/ChartAction.java
+++ b/Web/ExpressIM/src/com/stardust/express/actions/ChartAction.java
@@ -3,17 +3,14 @@ package com.stardust.express.actions;
 import com.stardust.express.bo.HistoryRecordBO;
 import com.stardust.express.dao.abstracts.IHistoryRecordGate.PeriodSummaryType;
 
-import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.List;
 import java.util.Map;
 
-import static com.opensymphony.xwork2.Action.SUCCESS;
 
 /**
  * Created by Administrator on 2017/4/26 0026.
  */
-public class ChartAction extends HistoryAction {
+public class ChartAction extends ActionExecutor {
 
     private Map<String, Integer> summaryResponse;
 

--- a/Web/ExpressIM/src/com/stardust/express/actions/ChartAction.java
+++ b/Web/ExpressIM/src/com/stardust/express/actions/ChartAction.java
@@ -13,11 +13,11 @@ import static com.opensymphony.xwork2.Action.SUCCESS;
 /**
  * Created by Administrator on 2017/4/26 0026.
  */
-public class ChartAction extends ActionExecutor {
+public class ChartAction extends HistoryAction {
 
-    private Map<String, Object> summaryResponse;
+    private Map<String, Integer> summaryResponse;
 
-    public Map<String, Object> getResult() {
+    public Map<String, Integer> getResult() {
         return summaryResponse;
     }
 

--- a/Web/ExpressIM/src/com/stardust/express/bo/HistoryRecordBO.java
+++ b/Web/ExpressIM/src/com/stardust/express/bo/HistoryRecordBO.java
@@ -56,7 +56,19 @@ public class HistoryRecordBO extends AdminBO {
         return EmptyMapForDay;
     }
 
+    public Date getFirstDayOfMonth(Date date) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(date);
+        calendar.set(Calendar.DAY_OF_MONTH, 1);
+        return calendar.getTime();
+    }
+
     public Map<String, Integer> getPeriodSummaryMap(Date startDate, Date endDate, PeriodSummaryType summaryType) {
+
+        if(summaryType.equals(PeriodSummaryType.MONTH)){
+            startDate = getFirstDayOfMonth(startDate);
+            endDate = getFirstDayOfMonth(endDate);
+        }
 
         List<Object[]> summaryList = ((IHistoryRecordGate) gate).getPeriodSummaryData(startDate, endDate, summaryType);
         Map<String, Integer> summaryMap = summaryType.equals(PeriodSummaryType.HOUR) ? getEmptyMapForDay() : new HashMap<>();

--- a/Web/ExpressIM/src/com/stardust/express/bo/HistoryRecordBO.java
+++ b/Web/ExpressIM/src/com/stardust/express/bo/HistoryRecordBO.java
@@ -48,10 +48,23 @@ public class HistoryRecordBO extends AdminBO {
         }
     }
 
+    public Map<String, Object> everyDatetime() {
+        Map<String, Object> everyDatet = new HashMap<String, Object>();
+        for (int i = 0; i < 24; i++) {
+            everyDatet.put(String.valueOf(i), "0");
+        }
+        return everyDatet;
+    }
+
+
     public Map<String, Object> getPeriodSummaryMap(Date startDate, Date endDate, PeriodSummaryType summaryType) {
 
         List<Object[]> summaryList = ((IHistoryRecordGate) gate).getPeriodSummaryData(startDate, endDate, summaryType);
+        if (summaryType.equals(PeriodSummaryType.DAY)) {
+            Map<String, Object> summarymap = everyDatetime();
+        }
         Map<String, Object> summarymap = new HashMap<>();
+
         for (Object[] obj : summaryList) {
             String keyList = "";
             for (int j = 1; j < obj.length; j++) {

--- a/Web/ExpressIM/src/com/stardust/express/bo/HistoryRecordBO.java
+++ b/Web/ExpressIM/src/com/stardust/express/bo/HistoryRecordBO.java
@@ -48,29 +48,26 @@ public class HistoryRecordBO extends AdminBO {
         }
     }
 
-    public Map<String, Object> everyDatetime() {
-        Map<String, Object> everyDatet = new HashMap<String, Object>();
+    public Map<String, Integer> getEmptyMapForDay() {
+        Map<String, Integer> getEmptyMapForDay = new HashMap<String, Integer>();
         for (int i = 0; i < 24; i++) {
-            everyDatet.put(String.valueOf(i), "0");
+            getEmptyMapForDay.put(String.valueOf(i), 0);
         }
-        return everyDatet;
+        return getEmptyMapForDay;
     }
 
-
-    public Map<String, Object> getPeriodSummaryMap(Date startDate, Date endDate, PeriodSummaryType summaryType) {
+    public Map<String, Integer> getPeriodSummaryMap(Date startDate, Date endDate, PeriodSummaryType summaryType) {
 
         List<Object[]> summaryList = ((IHistoryRecordGate) gate).getPeriodSummaryData(startDate, endDate, summaryType);
-        if (summaryType.equals(PeriodSummaryType.DAY)) {
-            Map<String, Object> summarymap = everyDatetime();
+        Map<String, Integer> summarymap = new HashMap<>();
+        if (summaryType.equals(PeriodSummaryType.HOUR)) {
+            summarymap = getEmptyMapForDay();
+        }else{
+
         }
-        Map<String, Object> summarymap = new HashMap<>();
 
         for (Object[] obj : summaryList) {
-            String keyList = "";
-            for (int j = 1; j < obj.length; j++) {
-                keyList += obj[j];
-            }
-            summarymap.put(keyList, obj[0]);
+            summarymap.put((String)obj[1], (Integer)obj[0]);
         }
         return summarymap;
     }

--- a/Web/ExpressIM/src/com/stardust/express/bo/HistoryRecordBO.java
+++ b/Web/ExpressIM/src/com/stardust/express/bo/HistoryRecordBO.java
@@ -59,17 +59,15 @@ public class HistoryRecordBO extends AdminBO {
     public Map<String, Integer> getPeriodSummaryMap(Date startDate, Date endDate, PeriodSummaryType summaryType) {
 
         List<Object[]> summaryList = ((IHistoryRecordGate) gate).getPeriodSummaryData(startDate, endDate, summaryType);
-        Map<String, Integer> summarymap = new HashMap<>();
+        Map<String, Integer> summaryMap = new HashMap<>();
         if (summaryType.equals(PeriodSummaryType.HOUR)) {
-            summarymap = getEmptyMapForDay();
-        }else{
-
+            summaryMap = getEmptyMapForDay();
         }
 
         for (Object[] obj : summaryList) {
-            summarymap.put((String)obj[1], (Integer)obj[0]);
+            summaryMap.put(obj[1].toString(),new Integer(obj[0].toString()));
         }
-        return summarymap;
+        return summaryMap;
     }
 }
 

--- a/Web/ExpressIM/src/com/stardust/express/bo/HistoryRecordBO.java
+++ b/Web/ExpressIM/src/com/stardust/express/bo/HistoryRecordBO.java
@@ -49,23 +49,20 @@ public class HistoryRecordBO extends AdminBO {
     }
 
     public Map<String, Integer> getEmptyMapForDay() {
-        Map<String, Integer> getEmptyMapForDay = new HashMap<String, Integer>();
+        Map<String, Integer> EmptyMapForDay = new HashMap<String, Integer>();
         for (int i = 0; i < 24; i++) {
-            getEmptyMapForDay.put(String.valueOf(i), 0);
+            EmptyMapForDay.put(String.valueOf(i), 0);
         }
-        return getEmptyMapForDay;
+        return EmptyMapForDay;
     }
 
     public Map<String, Integer> getPeriodSummaryMap(Date startDate, Date endDate, PeriodSummaryType summaryType) {
 
         List<Object[]> summaryList = ((IHistoryRecordGate) gate).getPeriodSummaryData(startDate, endDate, summaryType);
-        Map<String, Integer> summaryMap = new HashMap<>();
-        if (summaryType.equals(PeriodSummaryType.HOUR)) {
-            summaryMap = getEmptyMapForDay();
-        }
+        Map<String, Integer> summaryMap = summaryType.equals(PeriodSummaryType.HOUR) ? getEmptyMapForDay() : new HashMap<>();
 
         for (Object[] obj : summaryList) {
-            summaryMap.put(obj[1].toString(),new Integer(obj[0].toString()));
+            summaryMap.put(obj[1].toString(), new Integer(obj[0].toString()));
         }
         return summaryMap;
     }

--- a/Web/ExpressIM/src/com/stardust/express/bo/HistoryRecordBO.java
+++ b/Web/ExpressIM/src/com/stardust/express/bo/HistoryRecordBO.java
@@ -49,11 +49,11 @@ public class HistoryRecordBO extends AdminBO {
     }
 
     public Map<String, Integer> getEmptyMapForDay() {
-        Map<String, Integer> EmptyMapForDay = new HashMap<String, Integer>();
+        Map<String, Integer> emptyMapForDay = new HashMap<String, Integer>();
         for (int i = 0; i < 24; i++) {
-            EmptyMapForDay.put(String.valueOf(i), 0);
+            emptyMapForDay.put(String.valueOf(i), 0);
         }
-        return EmptyMapForDay;
+        return emptyMapForDay;
     }
 
     public Date getFirstDayOfMonth(Date date) {

--- a/Web/ExpressIM/src/com/stardust/express/dao/implementations/HistoryRecordGate.java
+++ b/Web/ExpressIM/src/com/stardust/express/dao/implementations/HistoryRecordGate.java
@@ -76,21 +76,25 @@ public class HistoryRecordGate extends DataGate implements IHistoryRecordGate {
     public List getPeriodSummaryData(Date startDate, Date endDate, PeriodSummaryType summaryType) {
 
         String sumSatement = "";
+        String range = "";
         Session session = null;
         try {
             session = getSession();
             if (summaryType.equals(PeriodSummaryType.HOUR)) {
-                sumSatement = "DATEPART(HOUR,REOCRD_DATE) ";
+                sumSatement = "DATEPART(HOUR,REOCRD_DATE)  ";
+                range = "DATEPART(HOUR,REOCRD_DATE)";
             } else if (summaryType.equals(PeriodSummaryType.DAY)) {
-                sumSatement = "convert(varchar(10),REOCRD_DATE,120)";
+                sumSatement = " YEAR + '-' + MONTH + '-' + DAY as period ";
+                range = " YEAR,MONTH,DAY";
             } else {
-                sumSatement = "convert(varchar(7),REOCRD_DATE,120)";
+                sumSatement = "YEAR + '-' + MONTH as period";
+                range = " YEAR,MONTH";
             }
             SQLQuery query = session.createSQLQuery("select COUNT(0) count," + sumSatement
                     + " from dbo.EXPRESSWAY_GATEWAY_HISTORY where ? <=REOCRD_DATE and ? >=REOCRD_DATE group by "
-                    + sumSatement);
-            query.setDate(0,startDate);
-            query.setDate(1,endDate);
+                    + range);
+            query.setDate(0, startDate);
+            query.setDate(1, endDate);
             return query.list();
 
         } catch (Exception e) {

--- a/Web/ExpressIM/src/com/stardust/express/dao/implementations/HistoryRecordGate.java
+++ b/Web/ExpressIM/src/com/stardust/express/dao/implementations/HistoryRecordGate.java
@@ -76,23 +76,19 @@ public class HistoryRecordGate extends DataGate implements IHistoryRecordGate {
     public List getPeriodSummaryData(Date startDate, Date endDate, PeriodSummaryType summaryType) {
 
         String sumSatement = "";
-        String range = "";
         Session session = null;
         try {
             session = getSession();
             if (summaryType.equals(PeriodSummaryType.HOUR)) {
-                sumSatement = "COUNT(0) as amount ,DATEPART(HOUR,REOCRD_DATE) as hour ";
-                range = "DATEPART(HOUR,REOCRD_DATE)";
+                sumSatement = "DATEPART(HOUR,REOCRD_DATE) ";
             } else if (summaryType.equals(PeriodSummaryType.DAY)) {
-                sumSatement = "COUNT(0) grade,convert(varchar(10),REOCRD_DATE,120)";
-                range = " convert(varchar(10),REOCRD_DATE,120)";
+                sumSatement = "convert(varchar(10),REOCRD_DATE,120)";
             } else {
-                sumSatement = "COUNT(0) grade,convert(varchar(7),REOCRD_DATE,120)";
-                range = " convert(varchar(7),REOCRD_DATE,120)";
+                sumSatement = "convert(varchar(7),REOCRD_DATE,120)";
             }
-            SQLQuery query = session.createSQLQuery("select " + sumSatement
+            SQLQuery query = session.createSQLQuery("select COUNT(0) count," + sumSatement
                     + " from dbo.EXPRESSWAY_GATEWAY_HISTORY where ? <=REOCRD_DATE and ? >=REOCRD_DATE group by "
-                    + range);
+                    + sumSatement);
             query.setDate(0,startDate);
             query.setDate(1,endDate);
             return query.list();

--- a/Web/ExpressIM/src/com/stardust/express/dao/implementations/HistoryRecordGate.java
+++ b/Web/ExpressIM/src/com/stardust/express/dao/implementations/HistoryRecordGate.java
@@ -87,8 +87,8 @@ public class HistoryRecordGate extends DataGate implements IHistoryRecordGate {
                 sumSatement = "COUNT(0) grade,convert(varchar(10),REOCRD_DATE,120)";
                 range = " convert(varchar(10),REOCRD_DATE,120)";
             } else {
-                sumSatement = "COUNT(0) grade,convert(varchar(10),REOCRD_DATE,120)";
-                range = " convert(varchar(10),REOCRD_DATE,120)";
+                sumSatement = "COUNT(0) grade,convert(varchar(7),REOCRD_DATE,120)";
+                range = " convert(varchar(7),REOCRD_DATE,120)";
             }
             SQLQuery query = session.createSQLQuery("select " + sumSatement
                     + " from dbo.EXPRESSWAY_GATEWAY_HISTORY where ? <=REOCRD_DATE and ? >=REOCRD_DATE group by "

--- a/Web/ExpressIM/src/com/stardust/express/dao/implementations/HistoryRecordGate.java
+++ b/Web/ExpressIM/src/com/stardust/express/dao/implementations/HistoryRecordGate.java
@@ -78,19 +78,17 @@ public class HistoryRecordGate extends DataGate implements IHistoryRecordGate {
         String sumSatement = "";
         String range = "";
         Session session = null;
-
-
         try {
             session = getSession();
             if (summaryType.equals(PeriodSummaryType.HOUR)) {
                 sumSatement = "COUNT(0) as amount ,DATEPART(HOUR,REOCRD_DATE) as hour ";
                 range = "DATEPART(HOUR,REOCRD_DATE)";
             } else if (summaryType.equals(PeriodSummaryType.DAY)) {
-                sumSatement = "COUNT(0) as totalPerMonth,YEAR,MONTH,DAY";
-                range = " YEAR,MONTH,DAY";
+                sumSatement = "COUNT(0) grade,convert(varchar(10),REOCRD_DATE,120)";
+                range = " convert(varchar(10),REOCRD_DATE,120)";
             } else {
-                sumSatement = "COUNT(0) as totalPerMonth,YEAR,MONTH";
-                range = " YEAR,MONTH";
+                sumSatement = "COUNT(0) grade,convert(varchar(10),REOCRD_DATE,120)";
+                range = " convert(varchar(10),REOCRD_DATE,120)";
             }
             SQLQuery query = session.createSQLQuery("select " + sumSatement
                     + " from dbo.EXPRESSWAY_GATEWAY_HISTORY where ? <=REOCRD_DATE and ? >=REOCRD_DATE group by "

--- a/Web/ExpressIM/src/com/stardust/express/tools/ViewContext.java
+++ b/Web/ExpressIM/src/com/stardust/express/tools/ViewContext.java
@@ -9,130 +9,134 @@ import java.util.Map;
 import com.opensymphony.xwork2.ActionContext;
 
 public class ViewContext implements IViewContext {
-	
-	protected ActionContext context;
-	
-	protected HashMap<String, Object> parameters = new HashMap<String, Object>();
-	
-	public ViewContext(ActionContext context) {
-		this.context = context;
-		
-		for (String key : context.getParameters().keySet()) {
-			Object value = context.getParameters().get(key);
-			parameters.put(key, value);
-		}
-	}
-	
-	public Map<String, Object> getSession(){
-		return this.context.getSession();
-	}
-	
-	public Map<String, Object> getApplication(){
-		return this.context.getApplication();
-	}
-	
-	public Integer getInt(String paramName) {
-		return getInt(paramName, 0);
-	}
-	
-	public Integer getInt(String paramName, Integer defaultValue) {
-		Object value = parameters.get(paramName);
-		int results = defaultValue;
-		try {
-			String [] values =  (String [])value;
-			results = Integer.parseInt(values[0]);
-		} catch (Exception e){
-		} 
-		return results;
-	}
-	
-	public String getString(String paramName) {
-		return getString(paramName, "");
-	}
-	
-	public String getString(String paramName, String defaultValue) {
-		Object value = parameters.get(paramName);
-		String results = defaultValue;
-		try {
-			String [] values =  (String [])value;
-			results = values[0];
-		} catch (Exception e){
-		} 
-		return results;
-	}
-	
-	public long getLong(String paramName) {
-		return getLong(paramName, 0);
-	}
-	
-	public long getLong(String paramName, long defaultValue) {
-		Object value = parameters.get(paramName);
-		long results = defaultValue;
-		try {
-			String [] values =  (String [])value;
-			results = Long.parseLong(values[0]);
-		} catch (Exception e){
-		} 
-		return results;
-	}
-	
-	public boolean getBoolean(String paramName) {
-		return getBoolean(paramName, false);
-	}
-	
-	public boolean getBoolean(String paramName, boolean defaultValue) {
-		Object value = parameters.get(paramName);
-		boolean results = defaultValue;
-		try {
-			String [] values =  (String [])value;
-			results = Boolean.parseBoolean(values[0]);
-		} catch (Exception e){
-		} 
-		return results;
-	}
-	
-	public Date getDate(String paramName) {
-		return getDate(paramName, null);
-	}
-	
-	public Date getDate(String paramName, Date defaultValue) {
-		Object value = parameters.get(paramName);
-		Date results = defaultValue;
-		try {
-			String [] values =  (String [])value;
-			results = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse(values[0]);
-		} catch (Exception e){
-		} 
-		return results;
-	}
-	
-	public BigDecimal getDecimal(String paramName) {
-		return getDecimal(paramName, new BigDecimal(0));
-	}
-	
-	public BigDecimal getDecimal(String paramName, BigDecimal defaultValue) {
-		Object value = parameters.get(paramName);
-		BigDecimal results = defaultValue;
-		try {
-			String [] values =  (String [])value;
-			results = new BigDecimal(values[0]);
-		} catch (Exception e){
-		} 
-		return results;
-	}
-	
-	public double getDouble(String paramName) {
-		return getDouble(paramName, 0);
-	}
-	
-	public double getDouble(String paramName, double defaultValue) {
-		Object value = parameters.get(paramName);
-		double results = defaultValue;
-		try {
-			String [] values =  (String [])value;
-			results = Double.parseDouble(values[0]);
-		} catch (Exception e){
-		} 
-		return results;
-	}
+
+    protected ActionContext context;
+
+    protected HashMap<String, Object> parameters = new HashMap<String, Object>();
+
+    public ViewContext(ActionContext context) {
+        this.context = context;
+
+        for (String key : context.getParameters().keySet()) {
+            Object value = context.getParameters().get(key);
+            parameters.put(key, value);
+        }
+    }
+
+    public Map<String, Object> getSession() {
+        return this.context.getSession();
+    }
+
+    public Map<String, Object> getApplication() {
+        return this.context.getApplication();
+    }
+
+    public Integer getInt(String paramName) {
+        return getInt(paramName, 0);
+    }
+
+    public Integer getInt(String paramName, Integer defaultValue) {
+        Object value = parameters.get(paramName);
+        int results = defaultValue;
+        try {
+            String[] values = (String[]) value;
+            results = Integer.parseInt(values[0]);
+        } catch (Exception e) {
+        }
+        return results;
+    }
+
+    public String getString(String paramName) {
+        return getString(paramName, "");
+    }
+
+    public String getString(String paramName, String defaultValue) {
+        Object value = parameters.get(paramName);
+        String results = defaultValue;
+        try {
+            String[] values = (String[]) value;
+            results = values[0];
+        } catch (Exception e) {
+        }
+        return results;
+    }
+
+    public long getLong(String paramName) {
+        return getLong(paramName, 0);
+    }
+
+    public long getLong(String paramName, long defaultValue) {
+        Object value = parameters.get(paramName);
+        long results = defaultValue;
+        try {
+            String[] values = (String[]) value;
+            results = Long.parseLong(values[0]);
+        } catch (Exception e) {
+        }
+        return results;
+    }
+
+    public boolean getBoolean(String paramName) {
+        return getBoolean(paramName, false);
+    }
+
+    public boolean getBoolean(String paramName, boolean defaultValue) {
+        Object value = parameters.get(paramName);
+        boolean results = defaultValue;
+        try {
+            String[] values = (String[]) value;
+            results = Boolean.parseBoolean(values[0]);
+        } catch (Exception e) {
+        }
+        return results;
+    }
+
+    public Date getDate(String paramName) {
+        return getDate(paramName, null);
+    }
+
+    public Date getDate(String paramName, Date defaultValue) {
+        Object value = parameters.get(paramName);
+        Date results = defaultValue;
+        try {
+            String[] values = (String[]) value;
+            if (values[0].length() == 10) {
+                results = new SimpleDateFormat("yyyy-MM-dd").parse(values[0]);
+            } else {
+                results = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse(values[0]);
+            }
+        } catch (Exception e) {
+        }
+        return results;
+    }
+
+    public BigDecimal getDecimal(String paramName) {
+        return getDecimal(paramName, new BigDecimal(0));
+    }
+
+    public BigDecimal getDecimal(String paramName, BigDecimal defaultValue) {
+        Object value = parameters.get(paramName);
+        BigDecimal results = defaultValue;
+        try {
+            String[] values = (String[]) value;
+            results = new BigDecimal(values[0]);
+        } catch (Exception e) {
+        }
+        return results;
+    }
+
+    public double getDouble(String paramName) {
+        return getDouble(paramName, 0);
+    }
+
+    public double getDouble(String paramName, double defaultValue) {
+        Object value = parameters.get(paramName);
+        double results = defaultValue;
+        try {
+            String[] values = (String[]) value;
+            results = Double.parseDouble(values[0]);
+        } catch (Exception e) {
+        }
+        return results;
+    }
 }


### PR DESCRIPTION
# 本次修改的业务原因(Reason of this change)
- 从数据库中每小时查询的数据count为null对应的小时也不显示
- 这会造成前端显示不了完整的数据，用户体验较差
-修改SQL语句 
-再次修改SQL，加入格式（convert查询效率较低）

# 实现的设计方案(High level overview of this change)
- 新建一个Map数组key为0-23，value为"0",然后put查询的数据，这样当count为null，时间也会有
- 修改的是HistoryRecordBO,添加everyDatetime方法在该方法中建立Map数组key为0-23，value为"0",然后在getPeriodSummaryMap中判断
-因为SQL查询出来的字段自带格式，所以删掉foreach中的for循环 
-对按年查询使用 Calendar中的方法，是按年查询时忽略日 只查询年月（实际是其实月份的第一天到结束月份的第一天结束）

# 提交前的自检
提交前代码经过debug检查没有报错，数据显示正常